### PR TITLE
Update PostEditorHelper.php

### DIFF
--- a/app/Helpers/PostEditorHelper.php
+++ b/app/Helpers/PostEditorHelper.php
@@ -24,7 +24,7 @@ class PostEditorHelper
         }
 
         // Start with Elementor, otherwise the block editor will be returned.
-        $action = \filter_input(\INPUT_GET, 'action', \FILTER_SANITIZE_STRING);
+        $action = \filter_input(\INPUT_GET, 'action');
         if ($action === 'elementor') {
             return 'elementor';
         }


### PR DESCRIPTION
The constant "FILTER_SANITIZE_STRING" is deprecated since PHP 8.1. It will be removed in the future, causing the Yoast SEO plugin to crash in the admin panel. This code just effectively does the same as if($_GET['action'] === 'elementor'), filter_input is used to stop IDE complaints, and FILTER_SANITIZE_STRING is cargo-cult as it serves no purpose.  Changed to use no filter (will use the default UNSAFE_RAW), which will satisfy IDE.